### PR TITLE
style: polish code for ParticleElasticBodey && ParticleElastoplasticBody

### DIFF
--- a/Examples/App_SandRigid/main.cpp
+++ b/Examples/App_SandRigid/main.cpp
@@ -31,16 +31,18 @@ int main()
 
     switch (caseid)
     {
-        case 0:
+        case 0: {
             DemoParticleSandMultiRigid* demo = DemoParticleSandMultiRigid::getInstance();
             demo->createScene();
             demo->run();
             break;
-        case 1:
+        }
+        case 1: {
             DemoParticleSandRigid_Sphere* demo = DemoParticleSandRigid_Sphere::getInstance();
             demo->createScene();
             demo->run();
             break;
+        }
         default:
             break;
     }

--- a/Source/Dynamics/ParticleSystem/ParticleElasticBody.h
+++ b/Source/Dynamics/ParticleSystem/ParticleElasticBody.h
@@ -1,4 +1,17 @@
+/**
+ * @author     : He Xiaowei (Clouddon@sina.com)
+ * @date       : 2019-05-14
+ * @description: Declaration of ParticleElasticBody class, projective-peridynamics based elastic bodies
+ * @version    : 1.0
+ *
+ * @author     : Zhu Fei (feizhu@pku.edu.cn)
+ * @date       : 2021-07-20
+ * @description: poslish code
+ * @version    : 1.1
+ */
+
 #pragma once
+
 #include "ParticleSystem.h"
 
 namespace PhysIKA {
@@ -7,10 +20,13 @@ class ElasticityModule;
 template <typename>
 class PointSetToPointSet;
 
-/*!
-    *    \class    ParticleElasticBody
-    *    \brief    Peridynamics-based elastic object.
-    */
+/**
+ * ParticleElasticBody
+ * a scene node to simulate elastic bodies with the approach introduced in the paper
+ * <Projective Peridynamics for Modeling Versatile Elastoplastic Materials>
+ *
+ * @param TDataType  template parameter that represents aggregation of scalar, vector, matrix, etc.
+ */
 template <typename TDataType>
 class ParticleElasticBody : public ParticleSystem<TDataType>
 {
@@ -22,29 +38,84 @@ public:
     ParticleElasticBody(std::string name = "default");
     virtual ~ParticleElasticBody();
 
+    /**
+     * initialize the node
+     * @issue: Did the constructor do too much?
+     *
+     * @return       initialization status, currently always return true
+     */
     bool initialize() override;
+
+    /**
+     * advance the scene node in time
+     *
+     * @param[in] dt    the time interval between the states before&&after the call
+     */
     void advance(Real dt) override;
+
+    /**
+     * set current configuration as the new initial configuration
+     * the surface node is updated as well
+     */
     void updateTopology() override;
 
+    /**
+     * translate the particle initial configuration by a vector
+     * the surface node is updated as well
+     * Hence if this function is called during simulation, it will cause inconsistency between
+     * the node's current particle configuration and surface mesh.
+     *
+     * @param[in] t   the translation vector
+     *
+     * @return        true if succeed, false otherwise
+     */
     bool translate(Coord t) override;
+
+    /**
+     * scale the particle initial configuration
+     * the surface node is updated as well
+     * Hence if this function is called during simulation, it will cause inconsistency between
+     * the node's current particle configuration and surface mesh.
+     *
+     * @param[in] s   the scale factor, must be positive
+     *
+     * @return        true if succeed, false otherwise
+     */
     bool scale(Real s) override;
 
+    /**
+     * setter and getter of the elasticity module
+     */
     void                                         setElasticitySolver(std::shared_ptr<ElasticityModule<TDataType>> solver);
     std::shared_ptr<ElasticityModule<TDataType>> getElasticitySolver();
-    void                                         loadSurface(std::string filename);
 
+    /**
+     * load surface mesh from obj file
+     *
+     * @param[in] filename    path to the obj file
+     */
+    void loadSurface(std::string filename);
+
+    /**
+     * get mapping from particles to surface mesh
+     */
     std::shared_ptr<PointSetToPointSet<TDataType>> getTopologyMapping();
 
+    /**
+     * return the node representing the surface
+     */
     std::shared_ptr<Node> getSurfaceNode()
     {
         return m_surfaceNode;
     }
 
 public:
-    DEF_EMPTY_VAR(Horizon, Real, "Horizon");
+    DEF_EMPTY_VAR(Horizon, Real, "Horizon");  //!< horizon variable of peridynamics
+                                              //!< DEF_EMPTY_VAR macro expands to the definition of
+                                              //!< a private member var_Horizon and a public function varHorizon()
 
 private:
-    std::shared_ptr<Node> m_surfaceNode;
+    std::shared_ptr<Node> m_surfaceNode;  //!< surface mesh node, generally for rendering purposes
 };
 
 #ifdef PRECISION_FLOAT

--- a/Source/Dynamics/ParticleSystem/ParticleElastoplasticBody.h
+++ b/Source/Dynamics/ParticleSystem/ParticleElastoplasticBody.h
@@ -1,3 +1,15 @@
+/**
+ * @author     : He Xiaowei (Clouddon@sina.com)
+ * @date       : 2019-05-25
+ * @description: Declaration of ParticleElastoplasticBody class, projective-peridynamics based elastoplastic bodies
+ * @version    : 1.0
+ *
+ * @author     : Zhu Fei (feizhu@pku.edu.cn)
+ * @date       : 2021-07-21
+ * @description: poslish code
+ * @version    : 1.1
+ */
+
 #pragma once
 #include "ParticleSystem.h"
 
@@ -5,21 +17,19 @@ namespace PhysIKA {
 template <typename>
 class NeighborQuery;
 template <typename>
-class PointSetToPointSet;
-template <typename>
 class ParticleIntegrator;
 template <typename>
-class ElasticityModule;
-template <typename>
 class ElastoplasticityModule;
-template <typename>
-class DensityPBD;
 template <typename TDataType>
 class ImplicitViscosity;
-/*!
-    *    \class    ParticleElastoplasticBody
-    *    \brief    Peridynamics-based elastoplastic object.
-    */
+
+/**
+ * ParticleElastoplasticBody
+ * a scene node to simulate elastoplastic bodies with the approach introduced in the paper
+ * <Projective Peridynamics for Modeling Versatile Elastoplastic Materials>
+ *
+ * @param TDataType  template parameter that represents aggregation of scalar, vector, matrix, etc.
+ */
 template <typename TDataType>
 class ParticleElastoplasticBody : public ParticleSystem<TDataType>
 {
@@ -31,19 +41,66 @@ public:
     ParticleElastoplasticBody(std::string name = "default");
     virtual ~ParticleElastoplasticBody();
 
+    /**
+     * advance the scene node in time
+     *
+     * @param[in] dt    the time interval between the states before&&after the call
+     */
     void advance(Real dt) override;
 
+    /**
+     * set current configuration as the new initial configuration
+     * the surface node is updated as well
+     */
     void updateTopology() override;
 
+    /**
+     * initialize the node
+     * @issue: Did the constructor do too much?
+     *
+     * @return       initialization status, currently always return true
+     */
     bool initialize() override;
 
+    /**
+     * translate the particle initial configuration by a vector
+     * the surface node is updated as well
+     * Hence if this function is called during simulation, it will cause inconsistency between
+     * the node's current particle configuration and surface mesh.
+     *
+     * @param[in] t   the translation vector
+     *
+     * @return        true if succeed, false otherwise
+     */
     bool translate(Coord t) override;
+
+    /**
+     * scale the particle initial configuration
+     * the surface node is updated as well
+     * Hence if this function is called during simulation, it will cause inconsistency between
+     * the node's current particle configuration and surface mesh.
+     *
+     * @param[in] s   the scale factor, must be positive
+     *
+     * @return        true if succeed, false otherwise
+     */
     bool scale(Real s) override;
 
+    /**
+     * load surface mesh from obj file
+     *
+     * @param[in] filename    path to the obj file
+     */
     void loadSurface(std::string filename);
 
+    /**
+     * setter of the elastoplasticity module
+     */
     void setElastoplasticitySolver(std::shared_ptr<ElastoplasticityModule<TDataType>> solver);
 
+    /**
+     * return the node representing the surface
+     */
     std::shared_ptr<Node> getSurfaceNode()
     {
         return m_surfaceNode;
@@ -53,14 +110,12 @@ public:
     VarField<Real> m_horizon;
 
 private:
-    std::shared_ptr<Node> m_surfaceNode;
+    std::shared_ptr<Node> m_surfaceNode;  //!< surface mesh node, generally for rendering purposes
 
-    std::shared_ptr<ParticleIntegrator<TDataType>>     m_integrator;
-    std::shared_ptr<NeighborQuery<TDataType>>          m_nbrQuery;
-    std::shared_ptr<ElasticityModule<TDataType>>       m_elasticity;
-    std::shared_ptr<ElastoplasticityModule<TDataType>> m_plasticity;
-    std::shared_ptr<DensityPBD<TDataType>>             m_pbdModule;
-    std::shared_ptr<ImplicitViscosity<TDataType>>      m_visModule;
+    std::shared_ptr<ParticleIntegrator<TDataType>>     m_integrator;  //!< the integrator to step forward in time
+    std::shared_ptr<NeighborQuery<TDataType>>          m_nbrQuery;    //!< query particle neighbors
+    std::shared_ptr<ElastoplasticityModule<TDataType>> m_plasticity;  //!< elastoplasticity constitutive model
+    std::shared_ptr<ImplicitViscosity<TDataType>>      m_visModule;   //!< viscosity model
 };
 
 #ifdef PRECISION_FLOAT

--- a/Source/Dynamics/ParticleSystem/ParticleSystem.cpp
+++ b/Source/Dynamics/ParticleSystem/ParticleSystem.cpp
@@ -1,8 +1,19 @@
-#include "ParticleSystem.h"
-#include "PositionBasedFluidModel.h"
+/**
+ * @author     : He Xiaowei (Clouddon@sina.com)
+ * @date       : 2019-05-14
+ * @description: Implementation of ParticleSystem class, base class of all particle-based methods
+ * @version    : 1.0
+ *
+ * @author     : Zhu Fei (feizhu@pku.edu.cn)
+ * @date       : 2021-07-20
+ * @description: poslish code
+ * @version    : 1.1
+ */
 
-#include "Framework/Topology/PointSet.h"
+#include "ParticleSystem.h"
+
 #include "Core/Utility.h"
+#include "Framework/Topology/PointSet.h"
 
 namespace PhysIKA {
 IMPLEMENT_CLASS_1(ParticleSystem, TDataType)
@@ -11,14 +22,8 @@ template <typename TDataType>
 ParticleSystem<TDataType>::ParticleSystem(std::string name)
     : Node(name)
 {
-    //        attachField(&m_velocity, MechanicalState::velocity(), "Storing the particle velocities!", false);
-    //        attachField(&m_force, MechanicalState::force(), "Storing the force densities!", false);
-
     m_pSet = std::make_shared<PointSet<TDataType>>();
     this->setTopologyModule(m_pSet);
-
-    //         m_pointsRender = std::make_shared<PointRenderModule>();
-    //         this->addVisualModule(m_pointsRender);
 }
 
 template <typename TDataType>
@@ -115,18 +120,6 @@ bool ParticleSystem<TDataType>::initialize()
     return Node::initialize();
 }
 
-//     template<typename TDataType>
-//     void ParticleSystem<TDataType>::setVisible(bool visible)
-//     {
-//         if (m_pointsRender == nullptr)
-//         {
-//             m_pointsRender = std::make_shared<PointRenderModule>();
-//             this->addVisualModule(m_pointsRender);
-//         }
-//
-//         Node::setVisible(visible);
-//     }
-
 template <typename TDataType>
 void ParticleSystem<TDataType>::updateTopology()
 {
@@ -161,15 +154,4 @@ bool ParticleSystem<TDataType>::resetStatus()
     return Node::resetStatus();
 }
 
-//     template<typename TDataType>
-//     std::shared_ptr<PointRenderModule> ParticleSystem<TDataType>::getRenderModule()
-//     {
-// //         if (m_pointsRender == nullptr)
-// //         {
-// //             m_pointsRender = std::make_shared<PointRenderModule>();
-// //             this->addVisualModule(m_pointsRender);
-// //         }
-//
-//         return m_pointsRender;
-//     }
 }  // namespace PhysIKA

--- a/Source/Dynamics/ParticleSystem/ParticleSystem.h
+++ b/Source/Dynamics/ParticleSystem/ParticleSystem.h
@@ -1,64 +1,118 @@
+/**
+ * @author     : He Xiaowei (Clouddon@sina.com)
+ * @date       : 2019-05-14
+ * @description: Declaration of ParticleSystem class, base class of all particle-based methods
+ * @version    : 1.0
+ *
+ * @author     : Zhu Fei (feizhu@pku.edu.cn)
+ * @date       : 2021-07-20
+ * @description: poslish code
+ * @version    : 1.1
+ */
+
 #pragma once
 #include "Framework/Framework/Node.h"
-//#include "Rendering/PointRenderModule.h"
 
 namespace PhysIKA {
 template <typename TDataType>
 class PointSet;
-/*!
-    *    \class    ParticleSystem
-    *    \brief    Position-based fluids.
-    *
-    *    This class implements a position-based fluid solver.
-    *    Refer to Macklin and Muller's "Position Based Fluids" for details
-    *
-    */
+
+/**
+ * ParticleSystem
+ * Base class of all particle-based methods
+ * The class is generally NOT used to instantiate a scene node, it's subclasses are.
+ *
+ * @param TDataType  template parameter that represents aggregation of scalar, vector, matrix, etc.
+ */
 template <typename TDataType>
 class ParticleSystem : public Node
 {
     DECLARE_CLASS_1(ParticleSystem, TDataType)
 public:
-    bool                              self_update = true;
+    bool self_update = true;  //!< whether the node is responsible for its update
+                              //!< in some cases (quite rare), the state update of the node is handled by another node (e.g., its father)
+                              //!< the class implementers should enclose the update procedure in an if statement while implementing adanvce()
+
     typedef typename TDataType::Real  Real;
     typedef typename TDataType::Coord Coord;
 
     ParticleSystem(std::string name = "default");
     virtual ~ParticleSystem();
 
+    /**
+     * initialize cuboid-shaped particle distribution
+     * Behavior is undefined if invalid arguments are specified
+     *
+     * @param[in] lo          lower-corner coordinate of the cuboid
+     * @param[in] hi          higher-corner coordinate of the cuboid,
+     *                        element values should be larger than that of lo
+     * @param[in] distance    distance between particles, must be positive
+     */
     void loadParticles(Coord lo, Coord hi, Real distance);
+
+    /**
+     * initialize sphere-shaped particle distribution
+     * Behavior is undefined if invalid arguments are specified
+     *
+     * @param[in] center      coordinate of sphere center
+     * @param[in] r           radius of sphere, must be positive
+     * @param[in] distance    distance between particles, must be positive
+     *
+     */
     void loadParticles(Coord center, Real r, Real distance);
+
+    /**
+     * initialize particles from obj file
+     *
+     * @param[in] filename    path to the obj file
+     */
     void loadParticles(std::string filename);
 
+    /**
+     * translate the particle initial configuration by a vector
+     *
+     * @param[in] t   the translation vector
+     *
+     * @return        true if succeed, false otherwise
+     */
     virtual bool translate(Coord t);
+
+    /**
+     * scale the particle initial configuration
+     *
+     * @param[in] s   the scale factor, must be positive
+     *
+     * @return        true if succeed, false otherwise
+     */
     virtual bool scale(Real s);
 
+    /**
+     * set current configuration as the new initial configuration
+     */
     void updateTopology() override;
+
+    /**
+     * reset current configuration to initial configuration
+     *
+     * @return       true if succeed, false otherwise
+     */
     bool resetStatus() override;
 
-    //        std::shared_ptr<PointRenderModule> getRenderModule();
-
     /**
-         * @brief Particle position
-         */
-    DEF_EMPTY_CURRENT_ARRAY(Position, Coord, DeviceType::GPU, "Particle position");
-
-    /**
-         * @brief Particle velocity
-         */
-    DEF_EMPTY_CURRENT_ARRAY(Velocity, Coord, DeviceType::GPU, "Particle velocity");
-
-    /**
-         * @brief Particle force
-         */
-    DEF_EMPTY_CURRENT_ARRAY(Force, Coord, DeviceType::GPU, "Force on each particle");
+     * initialize the node
+     *
+     * @return       initialization status, currently always return true
+     */
+    bool initialize() override;
 
 public:
-    bool initialize() override;
-    //        virtual void setVisible(bool visible) override;
+    //DEF_EMPTY_CURRENT_ARRAY macro expands to a member variable definition and a getter member function
+    DEF_EMPTY_CURRENT_ARRAY(Position, Coord, DeviceType::GPU, "Particle position");    //!< current particle positions
+    DEF_EMPTY_CURRENT_ARRAY(Velocity, Coord, DeviceType::GPU, "Particle velocity");    //!< current particle velocities
+    DEF_EMPTY_CURRENT_ARRAY(Force, Coord, DeviceType::GPU, "Force on each particle");  //!< current forces on particles
 
 protected:
-    std::shared_ptr<PointSet<TDataType>> m_pSet;
-    //        std::shared_ptr<PointRenderModule> m_pointsRender;
+    std::shared_ptr<PointSet<TDataType>> m_pSet;  //!< point set that stores initial configuration
 };
 
 #ifdef PRECISION_FLOAT


### PR DESCRIPTION
Known issues while polishing the code:
1. dt argument is not used in ParticleElasticBody::advance(dt) && ParticleElastoplasticBody::advance(dt)
2. What does getAnimationPipline()->push_back() do? It is used inside constructor of ParticleElasticBody, but not in constructor of ParticleElastoplasticBody. Also, it is not used in ParticleElasticBody::setElasticity(), which causes behavior inconsistency with ParticleElasticBody's constructor.
3. pbdmodule and elasticity module are not used by ParticleElastoplasticBody, and they have been removed in this commit.
4. Unexpected behavior would occur if translate&&scale functions are called after simulation begins, since the functions perform operation on the reference configuration of the particles and the deformed surface meshes. The surface mesh should always conform to current particle configuration. The issue has been addressed in API comments.